### PR TITLE
Add warning to `OSSContentFormatter`

### DIFF
--- a/docs/extras/integrations/llms/azureml_endpoint_example.ipynb
+++ b/docs/extras/integrations/llms/azureml_endpoint_example.ipynb
@@ -28,8 +28,9 @@
     "\n",
     "To use the wrapper, you must [deploy a model on AzureML](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-use-foundation-models?view=azureml-api-2#deploying-foundation-models-to-endpoints-for-inferencing) and obtain the following parameters:\n",
     "\n",
-    "* `endpoint_api_key`: The API key provided by the endpoint\n",
-    "* `endpoint_url`: The REST endpoint url provided by the endpoint"
+    "* `endpoint_api_key`: Required - The API key provided by the endpoint\n",
+    "* `endpoint_url`: Required - The REST endpoint url provided by the endpoint\n",
+    "* `deployment_name`: Not required - The deployment name of the model using the endpoint"
    ]
   },
   {
@@ -44,6 +45,8 @@
     "* `DollyContentFormatter`: Formats request and response data for the Dolly-v2\n",
     "* `HFContentFormatter`: Formats request and response data for text-generation Hugging Face models\n",
     "* `LLamaContentFormatter`: Formats request and response data for LLaMa2\n",
+    "\n",
+    "*Note: `OSSContentFormatter` is being deprecated and replaced with `GPT2ContentFormatter`. The logic is the same but `GPT2ContentFormatter` is a more suitable name. You can still continue to use `OSSContentFormatter` as the changes are backwards compatibile.*\n",
     "\n",
     "Below is an example using a summarization model from Hugging Face."
    ]

--- a/libs/langchain/langchain/llms/azureml_endpoint.py
+++ b/libs/langchain/langchain/llms/azureml_endpoint.py
@@ -1,5 +1,6 @@
 import json
 import urllib.request
+import warnings
 from abc import abstractmethod
 from typing import Any, Dict, List, Mapping, Optional
 
@@ -116,7 +117,7 @@ class ContentFormatterBase:
 
 
 class GPT2ContentFormatter(ContentFormatterBase):
-    """Content handler for LLMs from the OSS catalog."""
+    """Content handler for GPT2"""
 
     def format_request_payload(self, prompt: str, model_kwargs: Dict) -> bytes:
         prompt = ContentFormatterBase.escape_special_characters(prompt)
@@ -127,6 +128,28 @@ class GPT2ContentFormatter(ContentFormatterBase):
 
     def format_response_payload(self, output: bytes) -> str:
         return json.loads(output)[0]["0"]
+
+
+class OSSContentFormatter(ContentFormatterBase):
+    """Deprecated: Kept for backwards compatibility
+
+    Content handler for LLMs from the OSS catalog."""
+
+    content_formatter: Any = None
+
+    def __init__(self) -> None:
+        self.content_formatter = GPT2ContentFormatter()
+
+    def format_request_payload(self, prompt: str, model_kwargs: Dict) -> bytes:
+        warnings.warn(
+            """`OSSContentFormatter` will be deprecated in the future. 
+                      Please use `GPT2ContentFormatter` instead.  
+                      """
+        )
+        return self.content_formatter.format_request_payload(prompt, model_kwargs)
+
+    def format_response_payload(self, output: bytes) -> str:
+        return self.content_formatter.format_response_payload(output)
 
 
 class HFContentFormatter(ContentFormatterBase):

--- a/libs/langchain/tests/integration_tests/llms/test_azureml_endpoint.py
+++ b/libs/langchain/tests/integration_tests/llms/test_azureml_endpoint.py
@@ -12,8 +12,8 @@ from langchain.llms.azureml_endpoint import (
     AzureMLOnlineEndpoint,
     ContentFormatterBase,
     DollyContentFormatter,
-    GPT2ContentFormatter,
     HFContentFormatter,
+    OSSContentFormatter,
 )
 from langchain.llms.loading import load_llm
 
@@ -24,7 +24,7 @@ def test_gpt2_call() -> None:
         endpoint_api_key=os.getenv("OSS_ENDPOINT_API_KEY"),
         endpoint_url=os.getenv("OSS_ENDPOINT_URL"),
         deployment_name=os.getenv("OSS_DEPLOYMENT_NAME"),
-        content_formatter=GPT2ContentFormatter(),
+        content_formatter=OSSContentFormatter(),
     )
     output = llm("Foo")
     assert isinstance(output, str)
@@ -133,7 +133,7 @@ def test_incorrect_key() -> None:
             endpoint_api_key="incorrect-key",
             endpoint_url=os.getenv("OSS_ENDPOINT_URL"),
             deployment_name=os.getenv("OSS_DEPLOYMENT_NAME"),
-            content_formatter=GPT2ContentFormatter(),
+            content_formatter=OSSContentFormatter(),
         )
         llm("Foo")
 


### PR DESCRIPTION
# Description

`OSSContentFormatter` will use the new formatter `GPT2ContentFormatter` and issue a warning to switch to it as the name more properly describes what model it should be used for. Those using `OSSContentFormatter` will not have any breaking changes as this is simply a name change, and the logic is still the same.